### PR TITLE
Check for NULL pointer from create_app_config

### DIFF
--- a/lib/NewFangle/Config.pm
+++ b/lib/NewFangle/Config.pm
@@ -5,6 +5,7 @@ package NewFangle::Config {
   use 5.014;
   use NewFangle::FFI;
   use FFI::C::Util ();
+  use Carp ();
 
 # ABSTRACT: NewRelic Configuration class.
 
@@ -67,7 +68,7 @@ used.
     my($xsub, $class, %config) = @_;
     my $app_name    = delete $config{app_name}    // $ENV{NEWRELIC_APP_NAME}    // 'AppName';
     my $license_key = delete $config{license_key} // $ENV{NEWRELIC_LICENSE_KEY} // '';
-    my $config = $xsub->($app_name, $license_key);
+    my $config = $xsub->($app_name, $license_key) // Carp::croak("Error creating $class, bad license key");
     FFI::C::Util::perl_to_c($config, \%config);
     bless {
       config => $config,

--- a/t/newfangle_config.t
+++ b/t/newfangle_config.t
@@ -8,4 +8,13 @@ my $config = NewFangle::Config->new;
 isa_ok $config, 'NewFangle::Config';
 note Dump($config->to_perl);
 
+like(
+    dies {
+        local $ENV{NEWRELIC_LICENSE_KEY} = 'a' x 39;
+        NewFangle::Config->new;
+    },
+    qr/Error creating NewFangle::Config, bad license key/,
+    'constructor dies when create_app_config returns NULL pointer',
+);
+
 done_testing;


### PR DESCRIPTION
The C SDK function `create_app_config` returns a NULL pointer when any
of the following conditions are met:

 * app name is a NULL pointer
 * license key length is incorrect (len != 40)

This causes a cryptic error message because NewFangle::Config tries to
call `FFI::C::Util::perl_to_c` to initialize a (struct *) that is NULL:

```Not an object at ./NewFangle/Config.pm line 17.```

If `create_app_config` returns a NULL pointer, die with a helpful error
message instead of trying to continue.