### PR TITLE
remove empty line from HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ native Perl bindings and they can use the more obvious NewRelic namespace.
 
 <div>
     <p>On your dashboard side, you will get:</p>
-
     <div style="display: flex">
     <div style="margin: 3px; flex: 1 1 50%">
     <img alt="Test" src="/newrelic-dashboard-result.png" style="max-width: 100%">

--- a/lib/NewFangle.pm
+++ b/lib/NewFangle.pm
@@ -31,7 +31,6 @@ Or using a L<NewFangle::Config>:
 =begin html
 
 <p>On your dashboard side, you will get:</p>
-
 <div style="display: flex">
 <div style="margin: 3px; flex: 1 1 50%">
 <img alt="Test" src="/newrelic-dashboard-result.png" style="max-width: 100%">


### PR DESCRIPTION
This seems to fix the image for github README at least.